### PR TITLE
fix: add npm overrides for vulnerable transitive deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,11 @@
     "mocha": "^7.2.0",
     "should": "^10.0.0",
     "supertest": "^6.3.1"
+  },
+  "overrides": {
+    "qs": "6.14.1",
+    "minimatch": "3.1.3",
+    "js-yaml": "3.14.2",
+    "yargs-parser": "5.0.1"
   }
 }


### PR DESCRIPTION
## Automated npm overrides

This PR was created by `squish fix --overrides` to pin vulnerable transitive dependencies:

- `qs` → `6.14.1`
- `minimatch` → `3.1.3`
- `js-yaml` → `3.14.2`
- `yargs-parser` → `5.0.1`

### Alerts addressed:

- **qs** (high)
- **qs** (high)
- **minimatch** (high)
- **elliptic** (low)
- **qs** (medium)
- **js-yaml** (medium)
- **babel-traverse** (critical)
- **yargs-parser** (medium)